### PR TITLE
Implement a GitHub workflow to automatically run add_license.py

### DIFF
--- a/.github/workflows/add-license.yml
+++ b/.github/workflows/add-license.yml
@@ -35,7 +35,7 @@ jobs:
         fi
         
     - name: Commit changes
-      if: steps.changes.outputs.changes == "true"
+      if: steps.changes.outputs.changes == true
       run: |
         git config --global user.name "GitHub Actions Bot"
         git config --global user.email "actions@github.com"


### PR DESCRIPTION
- Add an automated GitHub workflow file to run the add_lincese.py script so that each file can be checked for license while being committed and ensure we are committing proper licensed code.